### PR TITLE
Require item and location name group functions

### DIFF
--- a/worlds/ufo50/__init__.py
+++ b/worlds/ufo50/__init__.py
@@ -88,6 +88,9 @@ class UFO50World(World):
     item_name_to_id = {k: v for game in ufo50_games.values() for k, v in game.items.get_items().items()}
     location_name_to_id = temp_ufo50_location_name_to_id
 
+    item_name_groups = {k: v for game in ufo50_games.values() for k, v in game.items.get_item_groups().items()}
+    location_name_groups = {k: v for game in ufo50_games.values() for k, v in game.locations.get_location_groups().items()}
+
     options_dataclass = options.UFO50Options
     options: options.UFO50Options
     settings_key = "ufo_50_settings"

--- a/worlds/ufo50/games/barbuta/items.py
+++ b/worlds/ufo50/games/barbuta/items.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, NamedTuple, List
+from typing import TYPE_CHECKING, Dict, NamedTuple, List, Set, Optional
 from BaseClasses import ItemClassification as IC, Item
 
 from ...constants import get_game_base_id
@@ -11,6 +11,7 @@ class ItemInfo(NamedTuple):
     id_offset: int
     classification: IC
     quantity: int
+    item_group: Optional[str] = None
 
 
 item_table: Dict[str, ItemInfo] = {
@@ -33,6 +34,13 @@ item_table: Dict[str, ItemInfo] = {
 # this is for filling out item_name_to_id, it should be static regardless of yaml options
 def get_items() -> Dict[str, int]:
     return {f"Barbuta - {name}": data.id_offset + get_game_base_id("Barbuta") for name, data in item_table.items()}
+
+
+# this should return the item groups for this game, independent of yaml options
+# you should include a group that contains all items for this game that is called the same thing as the game
+def get_item_groups() -> Dict[str, Set[str]]:
+    item_groups: Dict[str, Set[str]] = {"Barbuta": {f"Barbuta - {item_name}" for item_name in item_table.keys()}}
+    return item_groups
 
 
 # for when the world needs to create an item at random (like with random filler items)

--- a/worlds/ufo50/games/barbuta/items.py
+++ b/worlds/ufo50/games/barbuta/items.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, NamedTuple, List, Set, Optional
+from typing import TYPE_CHECKING, Dict, NamedTuple, List, Set
 from BaseClasses import ItemClassification as IC, Item
 
 from ...constants import get_game_base_id
@@ -11,7 +11,6 @@ class ItemInfo(NamedTuple):
     id_offset: int
     classification: IC
     quantity: int
-    item_group: Optional[str] = None
 
 
 item_table: Dict[str, ItemInfo] = {

--- a/worlds/ufo50/games/barbuta/locations.py
+++ b/worlds/ufo50/games/barbuta/locations.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, NamedTuple
+from typing import TYPE_CHECKING, Dict, NamedTuple, Set
 from BaseClasses import Region, Location
 
 from ...constants import get_game_base_id
@@ -47,6 +47,13 @@ location_table: Dict[str, LocationInfo] = {
 # this is for filling out location_name_to_id, it should be static regardless of yaml options
 def get_locations() -> Dict[str, int]:
     return {name: data.id_offset + get_game_base_id("Barbuta") for name, data in location_table.items()}
+
+
+# this should return the location groups for this game, independent of yaml options
+# you should include a group that contains all location for this game that is called the same thing as the game
+def get_location_groups() -> Dict[str, Set[str]]:
+    location_groups: Dict[str, Set[str]] = {"Barbuta": {f"Barbuta - {loc_name}" for loc_name in location_table.keys()}}
+    return location_groups
 
 
 # this is not a required function, but a recommended one -- the world class does not call this function


### PR DESCRIPTION
Your items.py needs a `get_item_groups` function and you locations.py needs a `get_location_groups` function, and they need to return, at minimum, an item/location group containing all items/locations in that game.