### PR TITLE
Implement Party House

### DIFF
--- a/worlds/ufo50/__init__.py
+++ b/worlds/ufo50/__init__.py
@@ -12,12 +12,12 @@ from . import options
 
 from .general_items import cartridge_items, cartridge_item_group
 
-from .games import barbuta, porgy, vainger, night_manor
+from .games import barbuta, porgy, vainger, night_manor, party_house
 from .games.barbuta import items, locations, regions
 from .games.porgy import items, locations, regions
 from .games.vainger import items, locations, regions
 from .games.night_manor import items, locations, regions
-
+from .games.party_house import items, locations, regions
 
 def launch_client(*args: str):
     from .Client import launch
@@ -86,6 +86,7 @@ ufo50_games: Dict = {
     "Porgy": porgy,
     "Vainger": vainger,
     "Night Manor": night_manor,
+    "Party House": party_house,
 }
 
 allowable_unimplemented: set[str] = {"Ninpek", "Magic Garden", "Velgress", "Waldorf's Journey"}

--- a/worlds/ufo50/games/party_house/__init__.py
+++ b/worlds/ufo50/games/party_house/__init__.py
@@ -1,0 +1,1 @@
+game_name = "Party House"

--- a/worlds/ufo50/games/party_house/items.py
+++ b/worlds/ufo50/games/party_house/items.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Dict, List, TYPE_CHECKING
+from typing import NamedTuple, Dict, List, Set, TYPE_CHECKING
 from BaseClasses import ItemClassification as IC, Item
 
 from ...constants import get_game_base_id
@@ -18,6 +18,11 @@ item_table: Dict[str, ItemInfo] = {
 
 def get_items() -> Dict[str, int]:
     return {f"Party House - {name}": data.id_offset + get_game_base_id("Party House") for name, data in item_table.items()}
+
+def get_item_groups() -> Dict[str, Set[str]]:
+    item_groups: Dict[str, Set[str]] = {"Party House": {
+        f"Party House - {item_name}" for item_name in item_table.keys()}}
+    return item_groups
 
 def create_item(item_name: str, world: "UFO50World", item_class: IC = None) -> Item:
     base_id = get_game_base_id("Party House")

--- a/worlds/ufo50/games/party_house/items.py
+++ b/worlds/ufo50/games/party_house/items.py
@@ -1,0 +1,40 @@
+from typing import NamedTuple, Dict, List, TYPE_CHECKING
+from BaseClasses import ItemClassification as IC, Item
+
+from ...constants import get_game_base_id
+
+if TYPE_CHECKING:
+    from ... import UFO50World
+
+class ItemInfo(NamedTuple):
+    id_offset: int
+    classification: IC
+    quantity: int = 1
+
+item_table: Dict[str, ItemInfo] = {
+    "+1 Starting Cash": ItemInfo(0, IC.filler, 3),
+    "+1 Starting Popularity": ItemInfo(1, IC.filler, 2)
+    }
+
+def get_items() -> Dict[str, int]:
+    return {f"Party House - {name}": data.id_offset + get_game_base_id("Party House") for name, data in item_table.items()}
+
+def create_item(item_name: str, world: "UFO50World", item_class: IC = None) -> Item:
+    base_id = get_game_base_id("Party House")
+    if item_name.startswith("Party House - "):
+        item_name = item_name.split(" - ", 1)[1]
+    item_data = item_table[item_name]
+    return Item(f"Party House - {item_name}", item_class or item_data.classification,
+                base_id + item_data.id_offset, world.player)
+
+def create_items(world: "UFO50World") -> List[Item]:
+    items_to_create: Dict[str, int] = {item_name: data.quantity for item_name, data in item_table.items()}
+    party_house_items: List[Item] = []
+
+    for item_name, quantity in items_to_create.items():
+        for _ in range(quantity):
+            party_house_items.append(create_item(item_name, world))
+    return party_house_items
+
+def get_filler_item_name(world: "UFO50World") -> str:
+    return world.random.choice(["Party House - +1 Starting Cash", "Party House - +1 Starting Popularity"])

--- a/worlds/ufo50/games/party_house/locations.py
+++ b/worlds/ufo50/games/party_house/locations.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING, Dict, NamedTuple, Set
+from BaseClasses import Region, Location, Item, ItemClassification
+from worlds.generic.Rules import add_rule
+
+from ...constants import get_game_base_id
+
+if TYPE_CHECKING:
+    from ... import UFO50World
+
+class LocationInfo(NamedTuple):
+    id_offset: int
+    region_name: str = "Menu"
+
+location_table: Dict[str, LocationInfo] = {
+    "Alien Invitation": LocationInfo(0),
+    "High or Low": LocationInfo(1),
+    "Best Wishes": LocationInfo(2),
+    "Money Management": LocationInfo(3),
+    "A Magical Night": LocationInfo(4),
+
+    "Garden": LocationInfo(997),
+    "Gold": LocationInfo(998),
+    "Cherry": LocationInfo(999)
+}
+
+def get_locations() -> Dict[str, int]:
+    return {f"Party House - {name}": data.id_offset + get_game_base_id("Party House") for name, data in location_table.items()}
+
+def get_location_groups() -> Dict[str, Set[str]]:
+    location_groups: Dict[str, Set[str]] = {"Party House": {f"Party House - {loc_name}"
+                                                            for loc_name in location_table.keys()}}
+    return location_groups
+
+def create_locations(world: "UFO50World", regions: Dict[str, Region]) -> None:
+    for loc_name, loc_data in location_table.items():
+        if loc_name == "Cherry" and "Party House" not in world.options.cherry_allowed_games:
+            break
+        if loc_name in ["Gold", "Cherry"] and "Party House" in world.goal_games:
+            if (loc_name == "Gold" and "Party House" not in world.options.cherry_allowed_games) or loc_name == "Cherry":
+                loc = Location(world.player, f"Party House - {loc_name}", None, regions[loc_data.region_name])
+                loc.place_locked_item(Item("Completed Party House", ItemClassification.progression, None, world.player))
+                add_rule(world.get_location("Completed All Games"), lambda state: state.has("Completed Party House", world.player))
+                regions[loc_data.region_name].locations.append(loc)
+                break
+
+        loc = Location(world.player, f"Party House - {loc_name}", get_game_base_id("Party House") + loc_data.id_offset,
+                       regions[loc_data.region_name])
+        regions[loc_data.region_name].locations.append(loc)

--- a/worlds/ufo50/games/party_house/locations.py
+++ b/worlds/ufo50/games/party_house/locations.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 class LocationInfo(NamedTuple):
     id_offset: int
-    region_name: str = "Menu"
+    region_name: str = "The Party House"
 
 location_table: Dict[str, LocationInfo] = {
     "Alien Invitation": LocationInfo(0),

--- a/worlds/ufo50/games/party_house/regions.py
+++ b/worlds/ufo50/games/party_house/regions.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from ... import UFO50World
 
 def create_regions_and_rules(world: "UFO50World") -> Dict[str, Region]:
-    party_house_menu = Region("Party House - Menu", world.player, world.multiworld)
-    party_house_regions = {"Menu": party_house_menu}
+    party_house_menu = Region("Party House - The Party House", world.player, world.multiworld)
+    party_house_regions = {"The Party House": party_house_menu}
     create_locations(world, party_house_regions)
     return party_house_regions

--- a/worlds/ufo50/games/party_house/regions.py
+++ b/worlds/ufo50/games/party_house/regions.py
@@ -8,5 +8,6 @@ if TYPE_CHECKING:
 
 def create_regions_and_rules(world: "UFO50World") -> Dict[str, Region]:
     party_house_menu = Region("Party House - Menu", world.player, world.multiworld)
-    create_locations(world, {"Party House - Menu": party_house_menu})
-    return {"Party House - Menu": party_house_menu}
+    party_house_regions = {"Menu": party_house_menu}
+    create_locations(world, party_house_regions)
+    return party_house_regions

--- a/worlds/ufo50/games/party_house/regions.py
+++ b/worlds/ufo50/games/party_house/regions.py
@@ -1,0 +1,12 @@
+from typing import Dict, TYPE_CHECKING
+from BaseClasses import Region
+
+from .locations import create_locations
+
+if TYPE_CHECKING:
+    from ... import UFO50World
+
+def create_regions_and_rules(world: "UFO50World") -> Dict[str, Region]:
+    party_house_menu = Region("Party House - Menu", world.player, world.multiworld)
+    create_locations(world, {"Party House - Menu": party_house_menu})
+    return {"Party House - Menu": party_house_menu}


### PR DESCRIPTION
Plain and simple, here's an APWorld addition for Party House as an integrated game. Built it in one night. Still very much requires someone to build a client, so feel free to have this one rot in the PRs until you've got something that can accept it.

Adds 5 total locations -- one for completing each challenge afforded to Party House. There's no logical restrictions on them beyond that of acquiring the game cartridge, so this game is not really appropriate as a solo game. It effectively just adds more locations to one of the slower games.

The two main items of the game are "+1 Starting Cash" and "+1 Starting Popularity", which, when received, should increment the appropriate value by 1 on Day 1 of any party house run. Entirely filler items, but should grease the wheel a little bit for less efficient players, and gives the generator something to chew on should you ACTUALLY wanna solo gen this game for some reason.