### PR TITLE
Make options uniformly delimited

### DIFF
--- a/worlds/ufo50/options.py
+++ b/worlds/ufo50/options.py
@@ -157,7 +157,7 @@ class NMEarlyPin(DefaultOnToggle):
     If enabled, the Hairpin will be on the floor in the starting room on either the Bowl or Spoon checks.
     """
     internal_name = "nm_early_pin"
-    display_name = "Night Manor Early Hairpin"
+    display_name = "Night Manor - Early Hairpin"
 
 
 @dataclass


### PR DESCRIPTION
Porgy option pretty names use a `-` to delimit between the game name and the option name. Night Manor does not, for some reason. This PR brings Night Manor's pretty name to the same standard.

Alternatively, we could remove the `-` delimiter from the Porgy options. Or, we could remove the game name from the options altogether (the option categories already do a good job at indicating what game they belong to). I guess this should have been an issue instead of a PR, but hey, lets talk about it I guess lol